### PR TITLE
Pass CLI exit code to Actions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,11 @@ command="pscale deploy-request deploy $1 $2 --org $3 -f json"
 
 cmdout=$(eval $command)
 
+ret=$?
+if [ $ret -ne 0 ]; then
+  exit $ret
+fi
+
 if [ "true" == "$4" ];then
   . /.pscale/cli-helper-scripts/wait-for-deploy-request-merged.sh
   wait_for_deploy_request_merged 9 "$1" "$2" "$3" 60

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Deploy a deploy request
-        uses: planetscale/deploy-deploy-request-action@v1
+        uses: planetscale/deploy-deploy-request-action@v2
         with:
           org_name: bmorrison-ps
           database_name: recipes_db


### PR DESCRIPTION
This update will pass the exit code from the CLI operations up to the Actions platform. This will properly flag the workflow step as a failure if something goes wrong while executing.